### PR TITLE
Support for Perl-like Variable Binding Syntax in Cowfiles

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,49 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "lldb",
+			"request": "launch",
+			"name": "Debug executable 'sh-toy'",
+			"cargo": {
+				"args": [
+					"build",
+					"--bin=sh-toy",
+					"--package=shell-toy"
+				],
+				"filter": {
+					"name": "sh-toy",
+					"kind": "bin"
+				}
+			},
+			"args": [
+				"-c",
+				"./cows/solid-snake.cow",
+				"test"
+			],
+			"cwd": "${workspaceFolder}"
+		},
+		{
+			"type": "lldb",
+			"request": "launch",
+			"name": "Debug unit tests in executable 'sh-toy'",
+			"cargo": {
+				"args": [
+					"test",
+					"--no-run",
+					"--bin=sh-toy",
+					"--package=shell-toy"
+				],
+				"filter": {
+					"name": "sh-toy",
+					"kind": "bin"
+				}
+			},
+			"args": [],
+			"cwd": "${workspaceFolder}"
+		}
+	]
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "sh-toy"
 path = "src/main.rs"
 
 [dependencies]
-owo-colors = "3"
+owo-colors = "4"
 nom = "7"
 tinyrand = "0.5"
 getrandom = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shell-toy"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "A \"cowsay | fortune\" implementation in Rust, i.e. a nice little toy to liven up your shell."
 license = "MIT"

--- a/src/cowsay.rs
+++ b/src/cowsay.rs
@@ -172,16 +172,20 @@ impl SpeechBubble {
 /***************************/
 pub fn derive_cow_str(parsed_chars: &[TerminalCharacter]) -> String {
     let mut environment: HashMap<String, Vec<TerminalCharacter>> = HashMap::new();
-
     //Because colors will change before characters are created, we take an owo_colors style
     // and use it as the "current style under tracking". As we created the string, we apply the style necessary to each character
     let mut current_style = owo_colors::Style::new().default_color();
+
+    let mut cow_started = false;
     //TODO Determine if we should pre-allocate the memory with an "estimate" for performance
     let mut cow_string = String::new();
     for term_char in parsed_chars {
         match term_char {
             TerminalCharacter::Space => {
-                cow_string = cow_string + format!("{}", " ".style(current_style)).as_str()
+                // if cow_started {
+                    //Assume first whitespace we see is part of the cow to output
+                    cow_string = cow_string + format!("{}", " ".style(current_style)).as_str()
+                // }
             }
             TerminalCharacter::DefaultForegroundColor => {
                 current_style = current_style.default_color()
@@ -207,7 +211,11 @@ pub fn derive_cow_str(parsed_chars: &[TerminalCharacter]) -> String {
             TerminalCharacter::ThoughtPlaceholder => cow_string = cow_string + "\\",
             TerminalCharacter::EyePlaceholder => cow_string = cow_string + "o o",
             TerminalCharacter::TonguePlaceholder => cow_string = cow_string + "  ",
-            TerminalCharacter::Newline => cow_string = cow_string + "\n",
+            TerminalCharacter::Newline => {
+                if cow_started {
+                    cow_string = cow_string + "\n";
+                }
+            }
             TerminalCharacter::Comment => (),
             TerminalCharacter::VarBinding(name, val) => {
                 environment.insert(name.to_string(), val.to_vec());
@@ -218,6 +226,7 @@ pub fn derive_cow_str(parsed_chars: &[TerminalCharacter]) -> String {
                     .expect("Could not find a binding with the specified name");
                 cow_string = cow_string + derive_cow_str(&binding_val).as_str();
             }
+            TerminalCharacter::CowStart => cow_started = true,
         }
     }
 

--- a/src/cowsay.rs
+++ b/src/cowsay.rs
@@ -206,6 +206,8 @@ pub fn derive_cow_str(parsed_chars: &[TerminalCharacter]) -> String {
             TerminalCharacter::TonguePlaceholder => cow_string = cow_string + "  ",
             TerminalCharacter::Newline => cow_string = cow_string + "\n",
             TerminalCharacter::Comment => (),
+			TerminalCharacter::VarBinding(_, _) => todo!(),
+			TerminalCharacter::BoundVarCall(_) => todo!(),
         }
     }
 

--- a/src/cowsay.rs
+++ b/src/cowsay.rs
@@ -1,5 +1,5 @@
 use crate::parser::{cow_parser, TerminalCharacter};
-use owo_colors::{OwoColorize, XtermColors};
+use owo_colors::{DynColor, OwoColorize, Style, XtermColors};
 use std::{
     collections::HashMap,
     error::Error,
@@ -170,11 +170,45 @@ impl SpeechBubble {
 /***************************/
 //End Derived Code
 /***************************/
-pub fn derive_cow_str(parsed_chars: &[TerminalCharacter]) -> String {
+//Wrapper type to contain the Style struct so it can be passed recursively
+struct StyleBuffer {
+    inner: Style,
+}
+
+impl StyleBuffer {
+    pub fn new() -> Self {
+        Self {
+            inner: owo_colors::Style::new().default_color().on_default_color(),
+        }
+    }
+
+    pub fn default_color(&mut self) {
+        self.inner = self.inner.default_color()
+    }
+
+    pub fn on_default_color(&mut self) {
+        self.inner = self.inner.on_default_color()
+    }
+
+    pub fn color(&mut self, color: impl DynColor) {
+        self.inner = self.inner.color(color)
+    }
+
+    pub fn on_color(&mut self, color: impl DynColor) {
+        self.inner = self.inner.on_color(color)
+    }
+
+    pub fn truecolor(&mut self, red: u8, green: u8, blue: u8) {
+        self.inner = self.inner.truecolor(red, green, blue)
+    }
+
+    pub fn on_truecolor(&mut self, red: u8, green: u8, blue: u8) {
+        self.inner = self.inner.on_truecolor(red, green, blue)
+    }
+}
+
+fn derive_cow_str(parsed_chars: &[TerminalCharacter], current_style: &mut StyleBuffer) -> String {
     let mut environment: HashMap<String, Vec<TerminalCharacter>> = HashMap::new();
-    //Because colors will change before characters are created, we take an owo_colors style
-    // and use it as the "current style under tracking". As we created the string, we apply the style necessary to each character
-    let mut current_style = owo_colors::Style::new().default_color();
 
     let mut cow_started = false;
     //TODO Determine if we should pre-allocate the memory with an "estimate" for performance
@@ -183,30 +217,26 @@ pub fn derive_cow_str(parsed_chars: &[TerminalCharacter]) -> String {
         match term_char {
             TerminalCharacter::Space => {
                 // if cow_started {
-                    //Assume first whitespace we see is part of the cow to output
-                    cow_string = cow_string + format!("{}", " ".style(current_style)).as_str()
+                //Assume first whitespace we see is part of the cow to output
+                cow_string = cow_string + format!("{}", " ".style(current_style.inner)).as_str()
                 // }
             }
-            TerminalCharacter::DefaultForegroundColor => {
-                current_style = current_style.default_color()
-            }
-            TerminalCharacter::DefaultBackgroundColor => {
-                current_style = current_style.on_default_color()
-            }
+            TerminalCharacter::DefaultForegroundColor => current_style.default_color(),
+            TerminalCharacter::DefaultBackgroundColor => current_style.on_default_color(),
             TerminalCharacter::TerminalForegroundColor256(color) => {
-                current_style = current_style.color(XtermColors::from(*color))
+                current_style.color(XtermColors::from(*color))
             }
             TerminalCharacter::TerminalForegroundColorTruecolor(red, green, blue) => {
-                current_style = current_style.truecolor(*red, *green, *blue)
+                current_style.truecolor(*red, *green, *blue)
             }
             TerminalCharacter::TerminalBackgroundColor256(color) => {
-                current_style = current_style.on_color(XtermColors::from(*color))
+                current_style.on_color(XtermColors::from(*color))
             }
             TerminalCharacter::TerminalBackgroundColorTruecolor(red, green, blue) => {
-                current_style = current_style.on_truecolor(*red, *green, *blue);
+                current_style.on_truecolor(*red, *green, *blue);
             }
             TerminalCharacter::UnicodeCharacter(uchar) => {
-                cow_string = cow_string + format!("{}", uchar.style(current_style)).as_str()
+                cow_string = cow_string + format!("{}", uchar.style(current_style.inner)).as_str()
             }
             TerminalCharacter::ThoughtPlaceholder => cow_string = cow_string + "\\",
             TerminalCharacter::EyePlaceholder => cow_string = cow_string + "o o",
@@ -224,7 +254,7 @@ pub fn derive_cow_str(parsed_chars: &[TerminalCharacter]) -> String {
                 let binding_val = environment
                     .get(binding)
                     .expect("Could not find a binding with the specified name");
-                cow_string = cow_string + derive_cow_str(&binding_val).as_str();
+                cow_string = cow_string + derive_cow_str(&binding_val, current_style).as_str();
             }
             TerminalCharacter::CowStart => cow_started = true,
         }
@@ -236,7 +266,14 @@ pub fn derive_cow_str(parsed_chars: &[TerminalCharacter]) -> String {
 //Effectively a main function in the sense it does all the heavy lifting.
 pub fn print_cowsay(cowsay: &str, bubble: SpeechBubble, msg: &str) {
     let mut nom_it = nom::combinator::iterator(cowsay, cow_parser);
-    let cow_str = derive_cow_str(nom_it.collect::<Vec<TerminalCharacter>>().as_slice());
+
+    //Because colors will change before characters are created, we take an owo_colors style
+    // and use it as the "current style under tracking". As we created the string, we apply the style necessary to each character
+    let mut style_buffer = StyleBuffer::new();
+    let cow_str = derive_cow_str(
+        nom_it.collect::<Vec<TerminalCharacter>>().as_slice(),
+        &mut style_buffer,
+    );
     // parse_raw_cow(cowsay, false);
     let msg_str = bubble
         .create(msg, 64 as usize)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,7 +2,7 @@
 /// couldn't be me hahahahahahaha
 use nom::{
     branch::alt,
-    bytes::complete::{tag, take, take_till, take_until, take_until1},
+    bytes::complete::{tag, take, take_until, take_until1},
     character::complete::{alphanumeric1, char, digit1, space0},
     combinator::{map, opt},
     error::ParseError,
@@ -193,6 +193,12 @@ fn perl_junk<'a, E: ParseError<&'a str>>(i: &'a str) -> IResult<&'a str, Termina
             tag("$the_cow = <<\"EOC\";\r\n"),
             tag("$the_cow = <<EOC;\n"),
             tag("$the_cow = <<EOC;\r\n"),
+            tag("$the_cow = << EOC;\n"),
+            tag("$the_cow = << EOC;\r\n"),
+            tag("$the_cow = << EOC\n"),
+            tag("$the_cow = << EOC\r\n"),
+            tag("$the_cow = <<EOC\n"),
+            tag("$the_cow = <<EOC\r\n"),
             tag("binmode STDOUT, \":utf8\";\n"),
             tag("binmode STDOUT, \":utf8\";\r\n"),
         )),


### PR DESCRIPTION
Wrote most of this while on a train to Leeds to visit the Royal Armories (highly recommend, had a great time). There are a few rules I listed because *apparently* Perl doesn't have a solidified BNF to implement (https://www.perlmonks.org/?node_id=471598). I've listed the rules in the `var_bindings` parser rule but here is a copy for reference.

https://github.com/FaceFTW/shell-toy/blob/74fff5aa878a48ed5359c80703fab8f92ca4c8d1/src/parser.rs#L127-L132

This should be placed in some kind of documentation in the future.

Closes #1 