### PR TITLE
Allow Compiling with Inline Fortune Data

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "fortunes"]
+	path = fortunes
+	url = https://github.com/shlomif/fortune-mod

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,11 +19,7 @@
 					"kind": "bin"
 				}
 			},
-			"args": [
-				"-c",
-				"./cows/solid-snake.cow",
-				"test"
-			],
+			"args": [],
 			"cwd": "${workspaceFolder}"
 		},
 		{

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,14 @@ argh = "0.1"
 textwrap = "0.16"
 strip-ansi-escapes = "0.2"
 unicode-width = "0.1"
-
+cfg-if = "1"
 
 [features]
+default=["inline", "fortune-git"]
 inline = []
 fortune-git = []
+
+
 
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shell-toy"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "A \"cowsay | fortune\" implementation in Rust, i.e. a nice little toy to liven up your shell."
 license = "MIT"
@@ -26,7 +26,6 @@ cfg-if = "1"
 default=[]
 inline = []
 fortune-git = []
-
 
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,10 @@ textwrap = "0.16"
 strip-ansi-escapes = "0.2"
 unicode-width = "0.1"
 
+
 [features]
 inline = []
+fortune-git = []
 
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ unicode-width = "0.1"
 cfg-if = "1"
 
 [features]
-default=["inline", "fortune-git"]
+default=[]
 inline = []
 fortune-git = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "A \"cowsay | fortune\" implementation in Rust, i.e. a nice little toy to liven up your shell."
 license = "MIT"
 repository = "https://github.com/FaceFTW/shell-toy"
-keywords = ["terminal","customization","fortune","cowsay","fortune-cookie"]
+keywords = ["terminal", "customization", "fortune", "cowsay", "fortune-cookie"]
 
 [[bin]]
 name = "sh-toy"
@@ -22,6 +22,7 @@ strip-ansi-escapes = "0.2"
 unicode-width = "0.1"
 
 [features]
+inline = []
 
 [profile.release]
 codegen-units = 1

--- a/build.rs
+++ b/build.rs
@@ -45,8 +45,9 @@ fn create_fortune_db() -> Result<(), io::Error> {
 fn gen_concat_fortune_files(val: String) -> Result<(), io::Error> {
     println!("cargo::rerun-if-changed={val}");
     let (fortune_list, offensive_list) = fortune_list_iterate(&PathBuf::from(val), false);
-    let concat_fortunes = concat_fortune_files(fortune_list.as_slice())?;
-    let off_concat_fortunes = concat_fortune_files(offensive_list.as_slice())?;
+    let concat_fortunes = concat_fortune_files(fortune_list.as_slice())?.replace("\r\n", "\n");
+    let off_concat_fortunes =
+        concat_fortune_files(offensive_list.as_slice())?.replace("\r\n", "\n");
     println!("{:#?}", offensive_list.as_slice());
     match File::create("target/resources/fortunes") {
         Ok(mut file) => {

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,162 @@
+use std::{
+    cell::LazyCell,
+    ffi::OsStr,
+    fs::{self, File},
+    io::{self, Read, Write},
+    path::PathBuf,
+};
+
+//This will likely always trigger because it just affects "pre-"compile time and not runtime
+fn main() -> Result<(), io::Error> {
+    create_fortune_db()
+}
+
+///
+fn create_fortune_db() -> Result<(), io::Error> {
+    if let Err(_) = fs::read_dir("target/resources") {
+        fs::create_dir("target/resources")?
+    }
+
+    if let Ok(val) = std::env::var("FORTUNE_FILE") {
+        println!("cargo::rerun-if-changed={val}");
+        let _ = fs::copy(val, "target/resources/fortunes")?;
+        Ok(())
+    } else if let Ok(val) = std::env::var("FORTUNE_PATH") {
+        gen_concat_fortune_files(val)
+    } else if let Ok(val) = std::env::var("FORTUNEPATH") {
+        gen_concat_fortune_files(val)
+    } else {
+        match std::env::consts::OS{
+            "linux" => gen_concat_fortune_files(String::from("/usr/share/games/fortune")),
+            _ => panic!("I don't know what the default path for fortunes are for this OS!.\nPlease provide a FORTUNEPATH or FORTUNE_PATH environment variable, or a single file with FORTUNE_FILE")
+        }
+    }
+}
+
+fn gen_concat_fortune_files(val: String) -> Result<(), io::Error> {
+    println!("cargo::rerun-if-changed={val}");
+    let (fortune_list, offensive_list) = fortune_list_iterate(&PathBuf::from(val), false);
+    let concat_fortunes = concat_fortune_files(fortune_list.as_slice())?;
+    let off_concat_fortunes = concat_fortune_files(offensive_list.as_slice())?;
+
+    match File::create("target/resources/fortunes") {
+        Ok(mut file) => {
+            let _ = file.write_all(concat_fortunes.trim().as_bytes())?;
+        }
+        Err(err) => panic!("Could not concatenate fortunes into single file: {err}"),
+    }
+    match File::create("target/resources/off_fortunes") {
+        Ok(mut file) => {
+            let _ = file.write_all(off_concat_fortunes.trim().as_bytes())?;
+        }
+        Err(err) => panic!("Could not concatenate fortunes into single file: {err}"),
+    }
+    Ok(())
+}
+
+//NOTE the following is copied over from the respective modules in the source tree since we can't use that code in the build script directly iirca
+
+//Used LazyCell because We use this in an OsStr comparison context
+//Adds effectively an O(1) operation based on my understanding
+pub const ILLEGAL_FILE_SUFFIXES: LazyCell<[&OsStr; 13]> = LazyCell::new(|| {
+    [
+        OsStr::new("dat"),
+        OsStr::new("pos"),
+        OsStr::new("c"),
+        OsStr::new("h"),
+        OsStr::new("p"),
+        OsStr::new("i"),
+        OsStr::new("f"),
+        OsStr::new("pas"),
+        OsStr::new("ftn"),
+        OsStr::new("ins.c"),
+        OsStr::new("ins.pas"),
+        OsStr::new("ins.ftn"),
+        OsStr::new("sml"),
+    ]
+});
+
+//this is somewhat memory inefficient but again, it's compile-time only
+fn fortune_list_iterate(path: &PathBuf, is_offensive: bool) -> (Vec<PathBuf>, Vec<PathBuf>) {
+    let mut fortune_list = vec![];
+    let mut offensive_list = vec![];
+    let dir_list = fs::read_dir(path).expect("Could not open directory");
+    for entry in dir_list.filter(|item| {
+        !ILLEGAL_FILE_SUFFIXES.contains(
+            &item
+                .as_ref()
+                .unwrap()
+                .path()
+                .extension()
+                .unwrap_or_default(),
+        )
+    }) {
+        match entry {
+            Ok(item) => match item.metadata().unwrap().is_dir() {
+                true => {
+                    if item.file_name() == "./off" {
+                        offensive_list.append(&mut fortune_list_iterate(&item.path(), true).1)
+                    } else {
+                        let vecs = &mut fortune_list_iterate(&item.path(), false);
+                        fortune_list.append(&mut vecs.0);
+                        offensive_list.append(&mut vecs.1);
+                    }
+                }
+                false => match is_offensive {
+                    true => offensive_list.push(item.path()),
+                    false => fortune_list.push(item.path()),
+                },
+            },
+            Err(e) => panic!("Could not identify a file in the fortune directory {e}"),
+        }
+    }
+    (fortune_list, offensive_list)
+}
+
+fn concat_fortune_files(list: &[PathBuf]) -> Result<String, io::Error> {
+    let mut buffer = String::new();
+    for path in list {
+        match File::open(path) {
+            Ok(mut file) => {
+                let _ = file.read_to_string(&mut buffer)?;
+            }
+            Err(err) => panic!("Could not open file: {err}"),
+        }
+    }
+    Ok(buffer)
+}
+
+// fn get_list_of_cows(path: &PathBuf) -> Result<Vec<String>, io::Error> {
+//     let mut total_list = vec![];
+//     let dir_list = fs::read_dir(path)?;
+//     for entry in dir_list {
+//         match entry {
+//             Ok(item) => match item.metadata()?.is_dir() {
+//                 true => total_list.append(get_list_of_cows(&item.path()).unwrap().as_mut()),
+//                 false => {
+//                     if item.path().extension().unwrap() == "cow" {
+//                         total_list.push(item.path().to_str().unwrap().to_string());
+//                     }
+//                 }
+//             },
+//             Err(e) => return Err(e),
+//         }
+//     }
+
+//     Ok(total_list)
+// }
+
+// fn identify_cow_path() -> PathBuf {
+//     //Check if we have an environment variable defined:
+//     let os = std::env::consts::OS;
+//     if let Ok(val) = std::env::var("COWPATH") {
+//         PathBuf::from(val.as_str())
+//     } else if let Ok(val) = std::env::var("COW_PATH") {
+//         PathBuf::from(val.as_str())
+//     } else {
+//         match os{
+//             "linux" => PathBuf::from("/usr/share/cowsay/cows"),
+//             _ => panic!("I don't know what the default path for cowfiles is for this OS!.\nPlease provide a COWPATH or COW_PATH environment variable")
+//         }
+//     }
+// }

--- a/build.rs
+++ b/build.rs
@@ -27,7 +27,7 @@ fn create_fortune_db() -> Result<(), io::Error> {
         gen_concat_fortune_files(val)
     } else {
         match std::env::consts::OS{
-            "linux" => gen_concat_fortune_files(String::from("/usr/share/games/fortune")),
+            "linux" => gen_concat_fortune_files(String::from("/usr/share/games/fortunes")),
             _ => panic!("I don't know what the default path for fortunes are for this OS!.\nPlease provide a FORTUNEPATH or FORTUNE_PATH environment variable, or a single file with FORTUNE_FILE")
         }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,6 +29,11 @@ pub(crate) struct Options {
 
     #[argh(positional)]
     pub message: Option<String>,
+
+    // #[cfg(feature = "inline")]
+    #[argh(option, short = 'f', long = "fortune-file")]
+    ///instead of using internal fortunes, which file/dir to look in
+    pub fortune_file: Option<String>,
 }
 
 fn parse_bubble_type(value: &str) -> Result<BubbleType, String> {

--- a/src/fortune.rs
+++ b/src/fortune.rs
@@ -21,15 +21,17 @@ pub fn get_fortune(file_path: PathBuf, rng: &mut impl Rand) -> Result<String, Bo
         Err(e) => panic!("Could not open Fortune file! {e}"),
     }
 }
+#[cfg(feature = "inline")]
+const INLINE_FORTUNES: &'static str = include_str!("../target/resources/fortunes");
+#[cfg(feature = "inline")]
+const OFF_FORTUNES: &'static str = include_str!("../target/resources/off_fortunes");
 
 #[cfg(feature = "inline")]
 pub fn get_inline_fortune(
     rng: &mut impl Rand,
     include_offensive: bool,
 ) -> Result<String, Box<dyn Error>> {
-    const INLINE_FORTUNES: &'static str = include_str!("../target/resources/fortunes");
-    const OFF_FORTUNES: &'static str = include_str!("../target/resources/off_fortunes");
-
+    //This is a fun little test
     let fortune_split: Vec<&str> = INLINE_FORTUNES
         .split("\n%\n")
         .into_iter()

--- a/src/fortune.rs
+++ b/src/fortune.rs
@@ -66,7 +66,7 @@ pub fn choose_fortune_file(
             .expect("Could not choose a random fortune file from the specified Fortune Path")
     } else {
         match os{
-            "linux" => PathBuf::from("/usr/share/games/fortune"),
+            "linux" => choose_fortune_file(include_offensive, rng,Some(String::from("/usr/share/games/fortunes"))),
             _ => panic!("I don't know what the default path for fortunes are for this OS!.\nPlease provide a FORTUNEPATH or FORTUNE_PATH environment variable, or a single file with FORTUNE_FILE")
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,9 @@ use std::{fs::File, io::Read, path::PathBuf};
 
 use cli::Options;
 use cowsay::{choose_random_cow, identify_cow_path, print_cowsay, SpeechBubble};
-use fortune::{choose_fortune_file, get_fortune, get_inline_fortune};
+#[cfg(feature = "inline")]
+use fortune::get_inline_fortune;
+use fortune::{choose_fortune_file, get_fortune};
 use tinyrand::{Seeded, StdRand};
 
 fn main() {


### PR DESCRIPTION
Closes #2 (Will reopen for implementing the cowsay part since that requires more effort)

Binary size will obviously increase linearly with the amount of fortune strings included. 
Issue will be created to allow for only inlining non-offensive fortunes (for now both are inline, use the `-o` flag)

Hyperfine was run to benchmark performance given it is likely all the inline data is loaded into memory (which only totals to about  ~5MB with default UNIX fortunes inlined). Results are on an Ubuntu WSL machine:
```
 zsh - face❯ hyperfine --warmup 5 -r 1000 "fortune | cowsay" "~/sh-toy"
Benchmark 1: fortune | cowsay
  Time (mean ± σ):      22.0 ms ±   1.6 ms    [User: 20.8 ms, System: 3.2 ms]
  Range (min … max):    20.6 ms …  33.6 ms    1000 runs

  Warning: The first benchmarking run for this command was significantly slower than the rest (27.6 ms). This could be caused by (filesystem) caches that were not filled until after the first run. You are already using the '--warmup' option which helps to fill these caches before the actual benchmark. You can either try to increase the warmup count further or re-run this benchmark on a quiet system in case it was a random outlier. Alternatively, consider using the '--prepare' option to clear the caches before each timing run.

Benchmark 2: ~/sh-toy
  Time (mean ± σ):       5.2 ms ±   0.6 ms    [User: 4.1 ms, System: 0.5 ms]
  Range (min … max):     4.5 ms …  13.0 ms    1000 runs

  Warning: Command took less than 5 ms to complete. Note that the results might be inaccurate because hyperfine can not calibrate the shell startup time much more precise than this limit. You can try to use the `-N`/`--shell=none` option to disable the shell completely.
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
``` 