### PR TITLE
Improvements to resolving Cow files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ fs_extra = "1.3"
 
 
 [features]
-default = ["inline-cowsay"]
+default = []
 inline-fortune = []
 inline-off-fortune = []
 inline-cowsay = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ fs_extra = "1.3"
 
 
 [features]
-default = []
+default = ["inline-cowsay"]
 inline-fortune = []
 inline-off-fortune = []
 inline-cowsay = []

--- a/build.rs
+++ b/build.rs
@@ -238,7 +238,12 @@ fn generate_cowsay_source() -> Result<(), std::io::Error> {
                     }
                     false => {
                         if item.path().extension().unwrap() == "cow" {
-                            let key = item.file_name().to_str().unwrap().to_string();
+                            let key = item
+                                .file_name()
+                                .to_str()
+                                .unwrap()
+                                .to_string()
+                                .replace(".cow", "");
                             match File::open(item.path()) {
                                 Ok(mut file) => {
                                     let mut value = String::new();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,21 +7,17 @@ use crate::cowsay::{BubbleType, CowVariant};
 pub(crate) struct Options {
     // #[cfg(not(feature = "inline-cowsay"))]
     #[argh(option, short = 'c')]
-    ///path to a direct cowfile
+    ///path to a direct cowfile OR the name of a cow that exists in the cow path
     pub cow_file: Option<String>,
 
     #[cfg(not(feature = "inline-cowsay"))]
     #[argh(option)]
-    ///path to a folder containing multiple cows we should search.
+    ///path to a folder containing cows that shell-toy should use.
     pub cow_path: Option<String>,
 
     #[argh(switch, short = 'l', long = "list-cows")]
     /// lists the cows that are embedded in the executable
     pub list_cows: bool,
-
-    #[argh(switch, short = 'o')]
-    /// whether to include offensive fortunes
-    pub include_offensive: bool,
 
     #[argh(
         option,
@@ -46,13 +42,17 @@ pub(crate) struct Options {
     /// This only affects cowfiles like the default cowsay cow which use the $eyes and/or $toungue variable
     pub cow_variant: CowVariant,
 
-    #[argh(positional)]
-    pub message: Option<String>,
-
     #[cfg(not(feature = "inline-fortune"))]
     #[argh(option, short = 'f', long = "fortune-file")]
     ///instead of using internal fortunes, which file/dir to look in
     pub fortune_file: Option<String>,
+
+    #[argh(switch, short = 'o')]
+    /// whether to include offensive fortunes
+    pub include_offensive: bool,
+
+    #[argh(positional)]
+    pub message: Option<String>,
 }
 
 fn parse_bubble_type(value: &str) -> Result<BubbleType, String> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,7 +15,6 @@ pub(crate) struct Options {
     ///path to a folder containing multiple cows we should search.
     pub cow_path: Option<String>,
 
-    #[cfg(feature = "inline-cowsay")]
     #[argh(switch, short = 'l', long = "list-cows")]
     /// lists the cows that are embedded in the executable
     pub list_cows: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,7 +15,12 @@ pub(crate) struct Options {
     ///path to a folder containing multiple cows we should search.
     pub cow_path: Option<String>,
 
-    #[argh(option, short = 'o', default = "false")]
+    #[cfg(feature = "inline-cowsay")]
+    #[argh(switch, short = 'l', long = "list-cows")]
+    /// lists the cows that are embedded in the executable
+    pub list_cows: bool,
+
+    #[argh(switch, short = 'o')]
     /// whether to include offensive fortunes
     pub include_offensive: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,7 @@ use crate::cowsay::{BubbleType, CowVariant};
 #[derive(FromArgs)]
 /// various program options
 pub(crate) struct Options {
-    #[cfg(not(feature = "inline-cowsay"))]
+    // #[cfg(not(feature = "inline-cowsay"))]
     #[argh(option, short = 'c')]
     ///path to a direct cowfile
     pub cow_file: Option<String>,

--- a/src/cowsay.rs
+++ b/src/cowsay.rs
@@ -270,10 +270,7 @@ fn derive_cow_str(
     for term_char in parsed_chars {
         match term_char {
             TerminalCharacter::Space => {
-                // if cow_started {
-                //Assume first whitespace we see is part of the cow to output
                 cow_string = cow_string + format!("{}", " ".style(current_style.inner)).as_str()
-                // }
             }
             TerminalCharacter::DefaultForegroundColor => current_style.default_color(),
             TerminalCharacter::DefaultBackgroundColor => current_style.on_default_color(),
@@ -348,6 +345,13 @@ pub fn print_cowsay(cowsay: &str, bubble: SpeechBubble, msg: &str, cow_variant: 
 pub fn choose_random_cow(rng: &mut impl Rand) -> String {
     let chosen_idx = rng.next_lim_usize(COW_DATA.len());
     COW_DATA[chosen_idx].1.to_string()
+}
+
+#[cfg(feature = "inline-cowsay")]
+pub fn get_cow_by_name(name: &str) -> Option<&str> {
+    COW_DATA
+        .into_iter()
+        .find_map(|item| if item.0 == name { Some(item.1) } else { None })
 }
 
 #[cfg(not(feature = "inline-cowsay"))]

--- a/src/cowsay.rs
+++ b/src/cowsay.rs
@@ -354,6 +354,13 @@ pub fn get_cow_by_name(name: &str) -> Option<&str> {
         .find_map(|item| if item.0 == name { Some(item.1) } else { None })
 }
 
+//Asserting static lifetimes becuase the only data returned from this is based in executable
+//data and is not dynamically generated
+#[cfg(feature = "inline-cowsay")]
+pub fn get_cow_names() -> [&'static str; COW_DATA.len()] {
+    COW_DATA.map(|val| val.0)
+}
+
 #[cfg(not(feature = "inline-cowsay"))]
 pub fn choose_random_cow(cow_path: &PathBuf, rng: &mut impl Rand) -> String {
     use std::{


### PR DESCRIPTION
`inline-cowsay` specific
- Added the ability to get a list of cows that exist in the executable
- Users can now specify what cow to use with the -c flag if it exists in the executable

non-`inline-cowsay` specific:
- Added the ability to list found cow files in the cow path (by argument, environment, or default OS location)
- Users no longer have to specify full paths for a cow file if it is located in the cow path